### PR TITLE
Added an example of using require.js's syntactic sugar for use when defining modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,7 +792,9 @@ define(['foo', 'bar'],
         return myModule;
 });
 ```
-There is also a [sugared version](http://requirejs.org/docs/whyamd.html#sugar) of `define()` available that would allow the previous code snippet to be written as:
+####Alternate syntax
+There is also a [sugared version](http://requirejs.org/docs/whyamd.html#sugar) of `define()` available that allows you to declare your dependencies as local variables using `require()`. This will feel familiar to anyone who's used node, and can be easier to add or remove dependencies.
+Here is the previous snippet using the alternate syntax:
 
 ```javascript
 // A module ID has been omitted here to make the module anonymous
@@ -816,7 +818,7 @@ define(function(require){
         return myModule;
 });
 ```
-Some people feel sytax is a more natural and maintainable way to specify your dependencies.
+
 
 The `require()` method is typically used to load code in a top-level JavaScript file or within a module should you wish to dynamically fetch dependencies. An example of its usage is:</p>
 

--- a/README.md
+++ b/README.md
@@ -792,9 +792,33 @@ define(['foo', 'bar'],
         return myModule;
 });
 ```
+There is also a [sugared version](http://requirejs.org/docs/whyamd.html#sugar) of `define()` available that would allow the previous code snippet to be written as:
 
+```javascript
+// A module ID has been omitted here to make the module anonymous
 
-<code>require()</code> on the other hand is typically used to load code in a top-level JavaScript file or within a module should you wish to dynamically fetch dependencies. An example of its usage is:</p>
+define(function(require){
+        // module definition function
+    // dependencies (foo and bar) are defined as local vars
+    var foo = require('foo'),
+        bar = require('bar');
+        
+        // return a value that defines the module export
+        // (i.e the functionality we want to expose for consumption)
+    
+        // create your module here
+        var myModule = {
+            doStuff:function(){
+                console.log('Yay! Stuff');
+            }
+        }
+
+        return myModule;
+});
+```
+Some people feel sytax is a more natural and maintainable way to specify your dependencies.
+
+The `require()` method is typically used to load code in a top-level JavaScript file or within a module should you wish to dynamically fetch dependencies. An example of its usage is:</p>
 
 ```javascript
 // Consider 'foo' and 'bar' are two external modules


### PR DESCRIPTION
I prefer this way of using define as it feels more natural and "JavaScripty", but am hesitant to change all examples of `define()` to this as I don't think it's the more widely-used syntax. Also, I'm not sure about the placement of the change - it might make more sense after the discussion of `require()`. 
