### PR TITLE
Add metadata file for epub/mobi generation via pandoc

### DIFF
--- a/INSTRUCTIONS-pandoc-ebooks.md
+++ b/INSTRUCTIONS-pandoc-ebooks.md
@@ -1,0 +1,13 @@
+Kindlegen requires title and author metadata. To generate a mobi file from
+a pandoc ebook, first generate an epub file using the metadata.xml file 
+included:
+
+```
+pandoc -f markdown -t epub --epub-metadata=metadata.xml -o backbone-fundamentals.epub README.md
+```
+
+then use the kindlegen tool to make a mobi from that epub:
+
+```
+kindlegen backbone-fundamentals.epub
+```

--- a/metadata.xml
+++ b/metadata.xml
@@ -1,0 +1,4 @@
+<dc:title>Developing Backbone.js Applications</dc:title>
+<dc:creator>Addy Osmani</dc:creator>
+<dc:rights>Creative Commons Attribution Non-Commercial Share Alike 3.0</dc:rights>
+<dc:language>en-US</dc:language>


### PR DESCRIPTION
Kindlegen requires title and author metadata.  To generate a mobi file from
a pandoc ebook, the pandoc ebook has to have that metadata via either code like
this at the top:

```
% Title
% Author
```

or via an external metadata file.  In order to keep the markdown clean, I added
as a separate file.  Ebooks w/ metadata can then be created via the command

```
pandoc -f markdown -t epub --epub-metadata=metadata.xml -o backbone-fundamnetals.epub README.md
```
