### PR TITLE
Update Collection.reset() section to explain that a reset event is fired instead of multiple add/remove events

### DIFF
--- a/index.md
+++ b/index.md
@@ -916,6 +916,7 @@ PhotoCollection.reset([
   {title: "The flight from Scotland", src: "long-flight.jpg"},
   {title: "Latest snap of lock-ness", src: "lockness.jpg"}]);
 ```
+Note that using `Collection.reset()` doesn't fire any `add` or `remove` events. A `reset` event is fired instead.
 
 ###Underscore utility functions
 


### PR DESCRIPTION
Hi Addy,

I thought it would be nice to make an observation about this on the section about the `Collection.reset()` method. Hope you agree.

Cheers!
