### PR TITLE
Fix searchPhotos handler on GalleryRouter example

### DIFF
--- a/index.md
+++ b/index.md
@@ -999,7 +999,8 @@ var GalleryRouter = Backbone.Router.extend({
     },
     
     searchPhotos: function(query, page){
-        console.log("Page number: " + page + " of the results for " + query);
+        var page_number = page || 1;
+        console.log("Page number: " + page_number + " of the results for " + query);
     },
     
     downloadPhoto: function(id, path){


### PR DESCRIPTION
Hi Addy,

I hope you also agree with this one. From the commit message:

Fix searchPhotos route handler not handling case where a reference
to a page number is not passed. In this case, the console.log
statement would print the page number as being 'undefined'.

The fix also helps to clarify that when the optional page reference
is not supplied, the 'page' parameter of the handling function will have
'undefined' as its value.

Cheers!
