### PR TITLE
Use cached version of the el jQuery object

### DIFF
--- a/index.md
+++ b/index.md
@@ -332,7 +332,7 @@ var PhotosController = Spine.Controller.sub({
   },
 
   remove: function(){
-    this.el.remove();
+    this.$el.remove();
     this.release();
   }
 });
@@ -474,7 +474,7 @@ var PhotoView = Backbone.View.extend({
 
     // Re-render the photo entry
     render: function() {
-      $(this.el).html(this.template(this.model.toJSON()));
+      this.$el.html(this.template(this.model.toJSON()));
       return this;
     },
 
@@ -755,7 +755,7 @@ var PhotoSearch = Backbone.View.extend({
     el: $('#results'),
     render: function( event ){
         var compiled_template = _.template( $("#results-template").html() );
-        this.el.html( compiled_template(this.model.toJSON()) );
+        this.$el.html( compiled_template(this.model.toJSON()) );
         return this; //recommended as this enables calls to be chained.
     },
     events: {
@@ -2684,7 +2684,7 @@ require(['js/app', 'text!templates/mainView.html'],
 That's it!. You can then go applying your template to a view in Backbone doing something like:
 
 ```javascript
-collection.someview.el.html( compiled_template( { results: collection.models } ) );
+collection.someview.$el.html( compiled_template( { results: collection.models } ) );
 ```
 
 
@@ -2958,7 +2958,7 @@ define([
 
     // Re-render the contents of the todo item.
     render: function() {
-      $(this.el).html(this.template(this.model.toJSON()));
+      this.$el.html(this.template(this.model.toJSON()));
       this.setContent();
       return this;
     },
@@ -3375,7 +3375,7 @@ function ($, _, facade) {
             context.model.save({
                 content: context.input.val()
             });
-            $(context.el).removeClass("editing");
+            context.$el.removeClass("editing");
         } catch (e) {
             //console.log(e);
         }
@@ -3411,7 +3411,7 @@ function ($, _, facade) {
     // Update editing UI on switching mode to editing content
     // Subscribes to: beginContentEditing
     facade.subscribe('editFocus','beginContentEditing', function (context) {
-        $(context.el).addClass("editing");
+        context.$el.addClass("editing");
         context.input.focus();
     });
 
@@ -4601,7 +4601,7 @@ If instead of testing against the ```tagName``` you would prefer to use a classN
 
 ```
 it('Should have a class of "todos"'), function(){
-   expect($(this.view.el)).toHaveClass('todos');
+   expect(this.view.$el).toHaveClass('todos');
 });
 ```
 
@@ -4693,7 +4693,7 @@ render: function() {
   var template = '<label class="todo-content"><%= text %></label>';
   var output = template
     .replace("<%= text %>", this.model.get('text'));
-  $(this.el).html(output);
+  this.$el.html(output);
   return this;
 }
 ```
@@ -4711,7 +4711,7 @@ describe("Template", function() {
   });
 
   it("has the correct text content", function() {
-    expect($(this.view.el).find('todo-content'))
+    expect(this.view.$('todo-content'))
       .toHaveText('My Todo');
   });
   
@@ -4791,7 +4791,7 @@ render: function() {
     '<%= text %></label>';
   var output = template
     .replace("<%= text %>", this.model.get('text'));
-  $(this.el).html(output);
+  this.$el.html(output);
   if (this.model.get('done')) {
     this.$(".todo-content").addClass("done");
   }
@@ -4814,7 +4814,7 @@ var TodoView = Backbone.View.extend({
   },
   
   render: function() {
-    $(this.el).html(this.template(this.model.toJSON()));
+    this.$el.html(this.template(this.model.toJSON()));
     return this;
   },
 


### PR DESCRIPTION
Instead of writing `$(this.el)` all around, I changed it to using `this.$el` instead. First of all it makes use of a cached version of the jQuery object and secondly I think it makes the code easier to read and that it's more idiomatic. Additionally, I think it clarifies `this.el` versus `this.$el` for those new to Backbone. I caught a couple of `.el` bugs at the same time, it seems.
