### PR TITLE
Corrected link to Rebecca Murphey's blog post

### DIFF
--- a/index.md
+++ b/index.md
@@ -1168,7 +1168,7 @@ var myConfig = {
 
 Note that there are really only minor syntactical differences between the Object Literal pattern and a standard JSON data set. If for any reason you wish to use JSON for storing your configurations instead (e.g. for simpler storage when sending to the back-end), feel free to.
 
-For more on the Object Literal pattern, I recommend reading Rebecca Murphey's [excellent article on the topic](http://blog.rebeccamurphey.com/2009/10/15/using-objects-to-organize-your-code).
+For more on the Object Literal pattern, I recommend reading Rebecca Murphey's [excellent article on the topic](http://rmurphey.com/blog/2009/10/15/using-objects-to-organize-your-code).
 
 **Nested namespacing**
 


### PR DESCRIPTION
The current link to Rebeca Murphey's blog post on using object literals for namespacing is incorrect.  I've updated it to the current correct URL.
