### PR TITLE
Sentence Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1947,7 +1947,7 @@ require([<span class="ch">&#39;foo&#39;</span>, <span class="ch">&#39;bar&#39;</
 require([<span class="ch">&#39;views/app&#39;</span>], <span class="kw">function</span>(AppView){
   <span class="kw">var</span> app_view = <span class="kw">new</span> AppView;
 });</code></pre>
-<p>The <code>require()</code> at the end of our main.js file is simply there so we can load and instantiate the primary view for our application (<code>views/app.js</code>). You'll commonly see both this and the configuration object included the most top-level script file for a project.</p>
+<p>The <code>require()</code> at the end of our main.js file is simply there so we can load and instantiate the primary view for our application (<code>views/app.js</code>). You'll commonly see both this and the configuration object included in most top-level script files for a project.</p>
 <p>In addition to offering name-mapping, the configuration object can be used to define additional properties such as <code>waitSeconds</code> - the number of seconds to wait before script loading times out and <code>locale</code>, should you wish to load up i18n bundles for custom languages. The <code>baseUrl</code> is simply the path to use for module lookups.</p>
 <p>For more information on configuration objects, please feel free to check out the excellent guide to them in the <a href="http://requirejs.org/docs/api.html#config">RequireJS docs</a>.</p>
 <h3 id="modularizing-our-models-views-and-collections">Modularizing our models, views and collections</h3>


### PR DESCRIPTION
This commit fixes a sentence so it reads correctly: "…this and the
configuration object included in most top-level script files for a
project."
