### PR TITLE
Updating Jade layouts for Express 3.x compatibility

### DIFF
--- a/practicals/stacks/option2/views/layout.jade
+++ b/practicals/stacks/option2/views/layout.jade
@@ -25,7 +25,8 @@ body
 
   #container
     header
-    #main(role="main")!=body
+    #main(role="main")
+      block content
     footer
   //! end of #container
 

--- a/practicals/stacks/option2/views/todo.jade
+++ b/practicals/stacks/option2/views/todo.jade
@@ -1,40 +1,42 @@
 // Todo App Interface
+extends layout
 
-#todoapp
-  .title
-    h1 Todos
-  .content
-    #create-todo
-      input#new-todo(placeholder="What needs to be done?", type="text")
-      span.ui-tooltip-top(style="display:none;") Press Enter to save this task
-    #todos
-      ul#todo-list
-    #todo-stats
+block content
+  #todoapp
+    .title
+      h1 Todos
+    .content
+      #create-todo
+        input#new-todo(placeholder="What needs to be done?", type="text")
+        span.ui-tooltip-top(style="display:none;") Press Enter to save this task
+      #todos
+        ul#todo-list
+      #todo-stats
 
 
-// Templates
-script#item-template(type="text/template")
-  <div class="todo <%= done ? 'done' : '' %>">
-  .display
-    <input class="check" type="checkbox" <%= done ? 'checked="checked"' : '' %> />
-    .todo-text 
-    span#todo-destroy
-  .edit
-    input.todo-input(type="text", "value"="")
-  </div>
+  // Templates
+  script#item-template(type="text/template")
+    <div class="todo <%= done ? 'done' : '' %>">
+    .display
+      <input class="check" type="checkbox" <%= done ? 'checked="checked"' : '' %> />
+      .todo-text 
+      span#todo-destroy
+    .edit
+      input.todo-input(type="text", "value"="")
+    </div>
 
-script#stats-template(type="text/template")
-  <% if (total) { %>
-  span.todo-count
-    span.number <%= remaining %> 
-    span.word <%= remaining == 1 ? 'item' : 'items' %>
-    |  left.
-  <% } %>
-  <% if (done) { %>
-  span.todo-clear
-    a(href="#")
-      |  Clear
-      span.number-done <%= done %>
-      |  completed
-      span.word-done <%= done == 1 ? 'item' : 'items' %>
-  <% } %>
+  script#stats-template(type="text/template")
+    <% if (total) { %>
+    span.todo-count
+      span.number <%= remaining %> 
+      span.word <%= remaining == 1 ? 'item' : 'items' %>
+      |  left.
+    <% } %>
+    <% if (done) { %>
+    span.todo-clear
+      a(href="#")
+        |  Clear
+        span.number-done <%= done %>
+        |  completed
+        span.word-done <%= done == 1 ? 'item' : 'items' %>
+    <% } %>


### PR DESCRIPTION
This fixes #156, making Jade template rendering compatible with Express 3.x. But note that it'll break rendering in 2.x.
