### PR TITLE
Backbone.sync mock example fix

### DIFF
--- a/index.md
+++ b/index.md
@@ -942,8 +942,10 @@ var methodMap = {
 In the above example if we wanted to log an event when `.sync()` was called, we could do this:
 
 ```javascript
+var id_counter = 1;
 Backbone.sync = function(method, model) {
   console.log("I've been passed " + method + " with " + JSON.stringify(model));
+  if(method === 'create'){ model.set('id', id_counter++); }
 };
 ```
 


### PR DESCRIPTION
Current example always only created items, because an "id" was not set
on the item. With this addition, items can go through the cycle of
create, update, delete.
