### PR TITLE
enhanced collection example

### DIFF
--- a/index.md
+++ b/index.md
@@ -925,11 +925,15 @@ var mySkiingCrash = PhotoCollection.getByCid(456);
 Backbone Collections don't have setters as such, but do support adding new models via `.add()` and removing models via `.remove()`.
 
 ```javascript
-var a = new Backbone.Model({ title: 'my vacation'}),
-    b = new Backbone.Model({ title: 'my holiday'});
+var a = new Photo({ title: 'my vacation'}),
+    b = new Photo({ title: 'my holiday'}),
+    c = new Photo({ title: 'my weekend'});
 
 var photoCollection = new PhotoCollection([a,b]);
+photoCollection.add(c);
+
 photoCollection.remove([a,b]);
+photoCollection.remove(c);
 ```
 
 **Listening for events**


### PR DESCRIPTION
Hi @addyosmani,
I've changed code example to be consisten with previous examples and extended example to show concreat add() in action as it is implicitly called out just before, so expected imo and experience reading it.

Also, I think it would be better to use Photo model instead of Backbone.Model as it could be confusing, even though a type of Backbone.Model is expected. Errors are thrown in case not all defaults of the expected Model type (in this case Photo) have counterparts in passed object to Backbone.Model when instantiating it and later those counterparts being used in app.

Should that be avoided, in general?

Cheers,
Dusan
