### PR TITLE
Add Makefile: simplify building outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+
+include_dir=build
+pandoc=`which pandoc`
+source=index.md
+title="Developing Backbone.js Applications"
+filename="backbone-fundamentals"
+pdflatex=`which pdflatex`
+
+all: pdf html epub rtf
+
+pdf: $(sorce)
+	$(pandoc) -s $(source) -o $(filename).tex -w latex \
+	       	--title-prefix=$(filename)
+	$(pdflatex) $(filename).tex
+
+html: $(source)
+	$(pandoc) -s $(source) -o index.html -c style.css \
+	       	--include-before-body=$(include_dir)/author.html \
+	       	--include-before-body=$(include_dir)/share.html \
+		--include-after-body=$(include_dir)/stats.html \
+	       	--title-prefix=$(title)
+
+epub: $(source)
+	$(pandoc) -s $(source) -t epub --epub-metadata=$(include_dir)/metadata.xml \
+	       	-o $(filename).epub --epub-stylesheet=epub.css --title-prefix=$(title) \
+		--epub-cover-image=img/cover.jpg
+
+clean: 
+	rm -f $(filename).aux \
+       		$(filename).db \
+	       	$(filename).log \
+		$(filename).out \
+	       	$(filename).tex


### PR DESCRIPTION
Hi!

With this commit you can "make" your documents.

Usage is as follows: 

``` sh
$> make pdf
```

 for PDFs

``` sh
$> make epub
```

for the epub version.

Hope this helps,

Andreas.
