### PR TITLE
In BBB section, Views.Foo should be Views.Bar

### DIFF
--- a/index.md
+++ b/index.md
@@ -2963,7 +2963,7 @@ function(app, Backbone) {
 
   var Views = {};
 
-  Views.Foo = Backbone.View.extend({
+  Views.Bar = Backbone.View.extend({
     template: "foo/bar",
     tagName: "li",
     ...


### PR DESCRIPTION
Typo in the name of this object, should be named Bar instead of Foo. It
is referenced later in the guide as Views.Bar.
