### PR TITLE
Typo in Model.get() sample code

### DIFF
--- a/index.md
+++ b/index.md
@@ -635,7 +635,7 @@ var todo2 = new Todo({
   completed: true
 });
 console.log(todo2.get('title')); // Retrieved with models get() method.
-console.log(todo2.get('completed')); // false
+console.log(todo2.get('completed')); // true
 ```
 
 If you need to read or clone all of a model's data attributes use its `toJSON` method. Despite the name it doesn't return a JSON string but a copy of the attributes as an object. ("toJSON" is part of the JSON.stringify specification. Passing an object with a toJSON method makes it stringify the return value of that method instead of the object itself.)


### PR DESCRIPTION
Hi Addy,
I hope this works, this is my first pull request. There is what seems a copy-paste mistake in the Model.get() sample code, it reads `console.log(todo2.get('completed')); // false`, but should be `console.log(todo2.get('completed')); // true`.

Thanks for the excellent book, still dumbfounded about Backbone, but getting there.

Regards
Stefan
