### PR TITLE
fixes backbone.paginator project url

### DIFF
--- a/index.md
+++ b/index.md
@@ -7305,7 +7305,7 @@ To learn more about Marionette, it's components, the features they provide and h
 
 Pagination is a ubiquitous problem we often find ourselves needing to solve on the web. Perhaps most predominantly when working with back-end APIs and JavaScript-heavy clients which consume them.
 
-On this topic, we're going to go through a set of **pagination components** I wrote for Backbone.js, which should hopefully come in useful if you're working on applications which need to tackle this problem. They're part of an extension called [Backbone.Paginator](http://github.com/addyosmani/backbone-paginator).
+On this topic, we're going to go through a set of **pagination components** I wrote for Backbone.js, which should hopefully come in useful if you're working on applications which need to tackle this problem. They're part of an extension called [Backbone.Paginator](http://github.com/addyosmani/backbone.paginator).
 
 When working with a structural framework like Backbone.js, the three types of pagination we are most likely to run into are:
 


### PR DESCRIPTION
Backbone.Paginator lives on the backbone.paginator repository, not backbone-paginator. This small commit address this issue.
