### PR TITLE
Update express declaration (chapter 9)

### DIFF
--- a/chapters/09-modular-development.md
+++ b/chapters/09-modular-development.md
@@ -1149,7 +1149,7 @@ Another advantage to defining all routes in a single location is that the same J
     var fs = require('fs'),
         _ = require('underscore'),
         express = require('express'),
-        server = express.createServer(),
+        server = express(),
         config = JSON.parse(fs.readFileSync('path/to/config.json'));
 
     _.each(config.modules, function(module, moduleName) {


### PR DESCRIPTION
Since express 3.x, `express.createServer()` is now simply `express()`.
However `express.createServer()` remains for backward compatibility, so it's not an essential fix.
