### PR TITLE
Use xelatex instead of pdflatex to handle all the unicode characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ pdf: markdown
 		--title-prefix $(title) \
 		--normalize \
 		--smart \
-		--toc
+		--toc \
+		--latex-engine=`which xelatex`
 
 mobi: epub
 	# Download: http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211


### PR DESCRIPTION
Not sure if texlive on Macs is configured differently, but I'm running linux and specifying xelatex as the latex engine is necessary to avoid error messages related to inputenc and unicode when generating PDF output.
