### PR TITLE
Repositioning the jquery <script> tag on template Markup

### DIFF
--- a/chapters/02-fundamentals.md
+++ b/chapters/02-fundamentals.md
@@ -91,9 +91,9 @@ Our example will need a div element to which we can attach a list of Todo's. It 
       <%- title %>
     </div>
   </script>
+  <script src="jquery-min.js"></script>
   <script src="underscore-min.js"></script>
   <script src="backbone-min.js"></script>
-  <script src="jquery-min.js"></script>
   <script src="example.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When i tried to run the template view example of Client-Side MVC - Backbone Style, the console.log gave me the next error:
"Uncaught TypeError: Property '$' of object #<Object> is not a function"

This happened because you had the jquery scrip tag on a wrong position, just below of backbone.min.js script tag.
Now i have changing the position, juts above of underscore-min.js script tag as a precaution.
