### PR TITLE
Corrected 'complete' to 'completed' in 03-internals/listeners code example

### DIFF
--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -205,7 +205,7 @@ console.log('Completed has changed: ' + myTodo.get('completed'));
 
 myTodo.set({
   title: 'Changing more than one attribute at the same time only triggers the listener once.',
-  'complete': true
+  completed: true
 });
 
 // Above logs:


### PR DESCRIPTION
03-internals.md listeners example no longer refers to nonexistent 'complete' attribute, as it should refer to 'completed' instead.
