### PR TITLE
the Backbone framework => Backbone

### DIFF
--- a/chapters/01-introduction.md
+++ b/chapters/01-introduction.md
@@ -84,7 +84,7 @@ Here is a peek at what you will be learning in each chapter:
 
 <i>Chapter 2, Fundamentals</i> traces the history of the MVC design pattern and introduces how it is implemented by Backbone.js and other JavaScript frameworks.
 
-<i>Chapter 3, Backbone Basics</i> covers the major features of the core Backbone.js framework and technologies and techniques you will need to know in order to apply it.
+<i>Chapter 3, Backbone Basics</i> covers the major features of the Backbone.js core and the technologies and techniques you will need to know in order to apply it.
 
 <i>Chapter 4, Exercise 1: Todos - Your First Backbone.js App</i> takes you step-by-step through development of a simple client-side Todo List application.
 

--- a/chapters/02-fundamentals.md
+++ b/chapters/02-fundamentals.md
@@ -4,7 +4,7 @@ Design patterns are proven solutions to common development problems that can hel
 
 Historically, developers creating desktop and server-class applications have had a wealth of design patterns available for them to lean on, but it's only been in the past few years that such patterns have been applied to client-side development.
 
-In this chapter, we're going to explore the evolution of the Model-View-Controller (MVC) design pattern and get our first look at how the Backbone.js framework allows us to apply this pattern to client-side development.
+In this chapter, we're going to explore the evolution of the Model-View-Controller (MVC) design pattern and get our first look at how Backbone.js allows us to apply this pattern to client-side development.
 
 ## MVC
 

--- a/chapters/05-exercise-2.md
+++ b/chapters/05-exercise-2.md
@@ -393,7 +393,7 @@ Create a file called `package.json` in the root of your project. It should look 
 {
 	"name": "backbone-library",
 	"version": "0.0.1",
-	"description": "A simple library application using the Backbone framework",
+	"description": "A simple library application using Backbone",
 	"dependencies": {
 		"express": "~3.1.0",
 		"path": "~0.4.9",


### PR DESCRIPTION
Early on, we're told that Backbone is "a library, rather than a framework" but it's referred to as a framework subsequently in a few places. It's more clear and direct to just say "Backbone" rather than "the Backbone framework" anyway, so here's that change.
