### PR TITLE
[pdf creation fix] Added etoolbox installation into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ You can build the book using `make` or `make -f Makefile`. This will output the 
 * <code>apt-get install texlive-latex-base</code>
 * <code>apt-get install texlive-fonts-recommended</code>
 * <code>apt-get install cm-super</code>
+* <code>apt-get install etoolbox</code>


### PR DESCRIPTION
Without `etoolbox` i got this error on my ubuntu 12.10:

```
➥ sudo apt-get install pandoc
➥ sudo apt-get install texlive-latex-base
➥ sudo apt-get install texlive-fonts-recommended
➥ sudo apt-get install cm-super
➥ make pdf 
awk 'FNR==1{print ""}{print}' chapters/*.md > 'backbone-fundamentals'.md
# You need `pdflatex`
# OS X: http://www.tug.org/mactex/
# Then find its path: find /usr/ -name "pdflatex"
# Then symlink it: ln -s /path/to/pdflatex /usr/local/bin
pandoc -s 'backbone-fundamentals'.md -o 'backbone-fundamentals'.pdf \
        --title-prefix 'Developing Backbone.js Applications' \
        --normalize \
        --smart \
        --toc
pandoc: Error producing PDF from TeX source.
! LaTeX Error: File `etoolbox.sty' not found.

Type X to quit or <RETURN> to proceed,
or enter new name. (Default extension: sty)

Enter file name: 
! Emergency stop.
<read *> 

l.28 \def

make: *** [pdf] Ошибка 43
```
