### PR TITLE
Fixed: Missing parentheses in Ch. 14 - QUnit Sample Code

### DIFF
--- a/chapters/12-qunit.md
+++ b/chapters/12-qunit.md
@@ -187,7 +187,7 @@ module( 'StoreList sanity check', {
         this.list.add(new Store({ name: 'Costcutter' }));
         this.list.add(new Store({ name: 'Target' }));
         this.list.add(new Store({ name: 'Walmart' }));
-        this.list.add(new Store({ name: 'Barnes & Noble' });
+        this.list.add(new Store({ name: 'Barnes & Noble' }));
     },
     teardown: function() {
         window.errors = null;


### PR DESCRIPTION
Parentheses is missing in last list.add of new Store and code does not work. Added missing parentheses.

``` js
// Define a group for our tests
module( 'StoreList sanity check', {
    setup: function() {
        this.list = new StoreList;
        this.list.add(new Store({ name: 'Costcutter' }));
        this.list.add(new Store({ name: 'Target' }));
        this.list.add(new Store({ name: 'Walmart' }));
        this.list.add(new Store({ name: 'Barnes & Noble' })); // Parentheses added here
    },
    teardown: function() {
        window.errors = null;
    }
});
```
