### PR TITLE
Fixed Marionette's class name in TodoMVC example

### DIFF
--- a/chapters/06-extensions.md
+++ b/chapters/06-extensions.md
@@ -324,7 +324,7 @@ First, we define an application object representing our base TodoMVC app. This w
 **TodoMVC.js:**
 
 ```javascript
-var TodoMVC = new Marionette.Application();
+var TodoMVC = new Backbone.Marionette.Application();
 
 TodoMVC.addRegions({
   header : '#header',


### PR DESCRIPTION
It was throwing a `Uncaught ReferenceError: Marionette is not defined`.
