### PR TITLE
Fix for #447.  Minor typo in Marionette example.

### DIFF
--- a/chapters/06-extensions.md
+++ b/chapters/06-extensions.md
@@ -189,7 +189,7 @@ var ZombieView = Backbone.View.extend({
 
   initialize: function(){
     // bind the model change to re-render this view
-    this.listenTo(this.model, 'change', this.render);
+    this.model.on('change', this.render, this);
   },
 
   close: function(){


### PR DESCRIPTION
In the example, the change from

```
this.model.on('change', this.render, this);
```

to

```
this.listenTo(this.model, 'change', this.render);
```

was made too soon.  By the time the text explains the change being made, it had already occurred earlier.
