### PR TITLE
Things that passed my mind when reading the Basics section

### DIFF
--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -212,12 +212,17 @@ Passing `{silent:true}` on change doesn't delay individual `"change:attr"` event
 
 ```javascript
 var Person = new Backbone.Model();
-Person.set({name: 'Jeremy'}, {silent: true});
+Person.on("change:name", function() { console.log('Name changed'); });
+Person.set({name: 'Andrew'});
+// log entry: Name changed
 
-console.log(!Person.hasChanged(0));
-// true
-console.log(!Person.hasChanged(''));
-// true
+Person.set({name: 'Jeremy'}, {silent: true});
+// no log entry
+
+console.log(Person.hasChanged("name"));
+// true: change was recorded
+console.log(Person.hasChanged(null));
+// true: something (anything) has changed
 ```
 
 Remember where possible it is best practice to use `Model.set()`, or direct instantiation as explained earlier.

--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -373,6 +373,12 @@ console.log('completed: ' + myTodo.get('completed')); // completed: false
 
 An example of this (by @fivetanley) is available [here](http://jsfiddle.net/2NdDY/7/).
 
+Note also, that validation on initialization is possible but of limited use, as the object being constructed is internally marked invalid but nevertheless passed back to the caller (continuing the above example):
+
+```javascript
+var emptyTodo = new Todo(null, {validate: true});
+console.log(emptyTodo.validationError);
+```
 
 ## Views
 


### PR DESCRIPTION
Reading the Basics section for the first time, there were some - though few - things I did not understand on a first read, though the rest is really well structured.
The first issue applies to an example for the Model.set() method, were unobvious uses of hasChanged are used, while the topic of the surrounding paragraphs is not fully demonstrated.
The second issue is an enhancement request, discussion validation in the context of initialization. As Jeremy Ashkenas points out, the current behaviour is going to stay: https://github.com/documentcloud/backbone/issues/2628
