### PR TITLE
changed 'trigger method' to 'trigger view event'

### DIFF
--- a/chapters/06-extensions.md
+++ b/chapters/06-extensions.md
@@ -924,7 +924,7 @@ A simple example would be an `on` helper that re-rendered the generated `HelperV
         });
     });
 
-An example use of this would be to have a counter that would increment each time a button was clicked. This example makes use of the `button` helper in Thorax which simply makes a button that calls a method when clicked:
+An example use of this would be to have a counter that would increment each time a button was clicked. This example makes use of the `button` helper in Thorax which simply makes a button that triggers a view event when clicked:
 
 ```handlebars
     {{#on "incremented"}}{{i}}{/on}}


### PR DESCRIPTION
button helpers can have both a method="" and trigger="". Method calls a method on the corresponding view, trigger triggers an event on the corresponding view.
