### PR TITLE
Update 06-extensions.md

### DIFF
--- a/chapters/06-extensions.md
+++ b/chapters/06-extensions.md
@@ -189,7 +189,7 @@ var ZombieView = Backbone.View.extend({
 
   initialize: function() {
     // bind the model change to re-render this view
-    this.model.on('change', this.render, this);
+    this.listenTo(this.model, 'change', this.render);
   },
 
   close: function() {


### PR DESCRIPTION
Hi, small fix:
When then zombieView's close function uses stopListening to remove the listener for the model, it will only work if it was registered with listenTo in the first place.
