### PR TITLE
typo in line 160 ("TodoView.render();" should be "todoView.render();"

### DIFF
--- a/chapters/02-fundamentals.md
+++ b/chapters/02-fundamentals.md
@@ -157,7 +157,7 @@ var TodoView = Backbone.View.extend({
     // Later we'll look at:
     // this.listenTo(someCollection, 'all', this.render);
     // but you can actually run this example right now by
-    // calling TodoView.render();
+    // calling todoView.render();
   },
 
   // Re-render the titles of the todo item.


### PR DESCRIPTION
There is a typo on line 160: "TodoView.render();" should be "todoView.render();" This calls the View class when it should call an instance of the View class.
