### PR TITLE
Function call changed before introduced in example.

### DIFF
--- a/chapters/06-extensions.md
+++ b/chapters/06-extensions.md
@@ -189,7 +189,7 @@ var ZombieView = Backbone.View.extend({
 
   initialize: function() {
     // bind the model change to re-render this view
-    this.listenTo(this.model, 'change', this.render);
+    this.model.on('change', this.render, this);
   },
 
   close: function() {


### PR DESCRIPTION
I was looking over the Marionette section and noticed that this function call changed prematurely before the example said to take notice of the new function call. 
