### PR TITLE
Remove usage of DOM.html( view.el ) as it's not recommended usage

### DIFF
--- a/chapters/06-extensions.md
+++ b/chapters/06-extensions.md
@@ -91,9 +91,9 @@ var myView = new MyView({
   model: Derick
 });
 
+myView.setElement("#content");
 myView.render();
 
-$('#content').html(myView.el);
 ```
 
 This is a standard set up for defining, building, rendering, and displaying a view with Backbone. This is also what we call "boilerplate code" - code that is repeated over and over and over again, across every project and every implementation with the same functionality. It gets to be tedious and repetitious very quickly.


### PR DESCRIPTION
The correct usage is to be view.setElement( DOMselector ).  Use case: If
a view has event listeners, upon the first DOM.html, event handlers are
setup correctly. Upon subsequent DOM.html calls, the event handlers are
not mapped, as jQuery's html method calls reset, which removes all event
handlers. Using the setElement ensures event handlers are set correctly.

For a demonstration, see http://jsfiddle.net/XNskF/
