### PR TITLE
Moved inconsistently placed comma in 03-internals.md

### DIFF
--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -1711,11 +1711,11 @@ var TodoRouter = Backbone.Router.extend({
         idea to leave them at the end of a URL otherwise you may need to apply regular
         expression parsing on your fragment */
 
-        "*other"    : "defaultRoute"
+        "*other"    : "defaultRoute",
         /* This is a default route that also uses a *splat. Consider the
         default route a wildcard for URLs that are either not matched or where
         the user has incorrectly typed in a route path manually */
-        /* Sample usage: http://example.com/# <anything> */,
+        /* Sample usage: http://example.com/# <anything> */
 
         "optional(/:item)": "optionalItem",
         "named/optional/(y:z)": "namedOptionalItem"


### PR DESCRIPTION
I noticed an inconsistently placed comma in `backbone-fundamentals/index.html#routers`.
