### PR TITLE
fixed links to base.css & bg.png

### DIFF
--- a/chapters/04-exercise-1.md
+++ b/chapters/04-exercise-1.md
@@ -59,7 +59,7 @@ Note: If you want to follow along, create a directory structure as demonstrated 
 2. Download jQuery, Underscore, Backbone, and Backbone LocalStorage from their respective web sites and place them under js/lib
 3. Create the directories js/models, js/collections, js/views, and js/routers
 
-You will also need [base.css](https://raw.github.com/tastejs/todomvc-common/master/base.css) and [bg.png](https://raw.github.com/tastejs/todomvc-common/master/bg.png), which should live in an assets directory. And remember that you can see a demo of the final application at [TodoMVC.com](http://todomvc.com).
+You will also need [base.css](https://github.com/tastejs/todomvc/blob/1.1.0/assets/base.css) and [bg.png](https://github.com/tastejs/todomvc/blob/1.1.0/assets/bg.png), which should live in an assets directory. And remember that you can see a demo of the final application at [TodoMVC.com](http://todomvc.com).
 
 We will be creating the application JavaScript files during the tutorial. Don't worry about the two 'text/template' script elements - we will replace those soon!
 


### PR DESCRIPTION
asset folder has meanwhile been renamed to [site-assets](https://github.com/tastejs/todomvc/tree/gh-pages/site-assets/), and base.css is now [main.css](https://github.com/tastejs/todomvc/blob/gh-pages/site-assets/main.css).

Instead of linking to the new files, I changed the links to v1.1.0 which still has the old files that this book is working with.
