### PR TITLE
Update 18-appendix.md

### DIFF
--- a/chapters/18-appendix.md
+++ b/chapters/18-appendix.md
@@ -43,8 +43,15 @@ var Events = Cranium.Events = {
     Cranium.Events.channels[events + --Cranium.Events.eventNumber] = callback;
   },
   // Unregisters an event type and its listener
-  off: function(topic) {
-    delete Cranium.Events.channels[topic];
+  off: function(events) {
+    var topic;
+    for (topic in Fuisz.Events.channels) {
+        if (Fuisz.Events.channels.hasOwnProperty(topic)) {
+            if (topic.split("-")[0] == events) {
+                delete Fuisz.Events.channels[topic];
+            }
+        }
+    }
   }            
 };
 ```


### PR DESCRIPTION
Since 'topic' is made dynamic and there is no track of it, off will never delete anything. So fast solution is to send event name (that can contain separation 'like module.part.event') and than delete all topics for it.
