### PR TITLE
reordered logs to match code sample

### DIFF
--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -923,8 +923,8 @@ TodosCollection.set([
 ]);
 
 // Above logs:
-// Removed go to Disneyland.
 // Completed go to Jamaica.
+// Removed go to Disneyland.
 // Added go to Disney World.
 ```
 


### PR DESCRIPTION
Here I thought I would reorder the logs in the same order as they appear in the console when using the above code sample. This order of logs has to do with the way Collection.set() works. Collection.set() merges existing and removes all non-existent models first and then adds new ones and sorts the list.
