### PR TITLE
Fix order of logs in the Resetting/Refreshing Collections section in Chapter 3

### DIFF
--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -923,8 +923,8 @@ TodosCollection.set([
 ]);
 
 // Above logs:
-// Removed go to Disneyland.
 // Completed go to Jamaica.
+// Removed go to Disneyland.
 // Added go to Disney World.
 ```
 


### PR DESCRIPTION
I noticed that the console output presented after the example code in Chapter 3 - Resetting/Refreshing Collections  was incorrectly ordered.  Here is a simple pull request to fix it.

I did run the code to ensure this is the correct output. 
