### PR TITLE
Fixed sync override example for collections

### DIFF
--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -2023,7 +2023,7 @@ Backbone.sync = function(method, model, options) {
       return MyAPI.destroy(model, success, error);
 
     case 'read':
-      if (model.attributes[model.idAttribute]) {
+      if (model.cid) {
         return MyAPI.find(model, success, error);
       } else {
         return MyAPI.findAll(model, success, error);


### PR DESCRIPTION
The sync override currently throws an error when fetch() is called on a Collection, because the argument `model` contains a collection object which doesn't contain `idAttribute`. For the sake of an uncluttered example, duck typing the model should suffice?
