### PR TITLE
Undefined 'order' model attribute

### DIFF
--- a/backbone-fundamentals.md
+++ b/backbone-fundamentals.md
@@ -2764,7 +2764,7 @@ The `Todo` model is remarkably straightforward. First, a todo has two attributes
 
   // Todo Model
   // ----------
-  // Our basic **Todo** model has `title`, `order`, and `completed` attributes.
+  // Our basic **Todo** model has `title` and `completed` attributes.
 
   app.Todo = Backbone.Model.extend({
 

--- a/chapters/04-exercise-1.md
+++ b/chapters/04-exercise-1.md
@@ -148,7 +148,7 @@ The `Todo` model is remarkably straightforward. First, a todo has two attributes
 
   // Todo Model
   // ----------
-  // Our basic **Todo** model has `title`, `order`, and `completed` attributes.
+  // Our basic **Todo** model has `title` and `completed` attributes.
 
   app.Todo = Backbone.Model.extend({
 

--- a/index.html
+++ b/index.html
@@ -2471,7 +2471,7 @@ collection
 
   <span class="co">// Todo Model</span>
   <span class="co">// ----------</span>
-  <span class="co">// Our basic **Todo** model has `title`, `order`, and `completed` attributes.</span>
+  <span class="co">// Our basic **Todo** model has `title` and `completed` attributes.</span>
 
   <span class="kw">app</span>.<span class="fu">Todo</span> = <span class="kw">Backbone.Model</span>.<span class="fu">extend</span>({
 


### PR DESCRIPTION
"Todo model" section in "Exercise 1" chapter mentions that the sample Todo Model has an `order` attribute, while in fact it doesn't.

I guess this is legacy from an early version of the sample, as from [practical's script.js](https://github.com/dprotti/backbone-fundamentals/blob/2e43d7460750c2b6a02d93f52420cf2aea385ea3/practicals/stacks/option1/public/js/script.js).
