### PR TITLE
Fix Airbnb capitalization.

### DIFF
--- a/chapters/02-fundamentals.md
+++ b/chapters/02-fundamentals.md
@@ -356,7 +356,7 @@ Walmart chose Backbone to power their mobile web applications, creating two new 
 ![](img/walmart-mobile.png)
 
 
-*AirBnb*
+*Airbnb*
 
 Airbnb developed their mobile web app using Backbone and now use it across many of their products.
 


### PR DESCRIPTION
Just another tiny fix.

Also, I noticed while reading this section that you treat organizations as plural: "Khan use Backbone", "Airbnb ... now use it". These sound awkward to me, but at least it's consistent. :)
