### PR TITLE
Send actual response from POST /api/books

### DIFF
--- a/chapters/05-exercise-2.md
+++ b/chapters/05-exercise-2.md
@@ -552,11 +552,11 @@ app.post( '/api/books', function( request, response ) {
 	});
 	book.save( function( err ) {
 		if( !err ) {
-			return console.log( 'created' );
+			console.log( 'created' );
+			return response.send( book );
 		} else {
 			return console.log( err );
 		}
-		return response.send( book );
 	});
 });
 ```


### PR DESCRIPTION
A `console.log` was returned from the `app.post` method as opposed to a `response.send` statement.
