### PR TITLE
Fix example reference at chapter 3

### DIFF
--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -482,7 +482,7 @@ Note: When declaring a View, `options`, `el`, `tagName`, `id` and `className` ma
 
 **$el and $()**
 
-View logic often needs to invoke jQuery or Zepto functions on the `el` element and elements nested within it. Backbone makes it easy to do so by defining the `$el` property and `$()` function. The `view.$el` property is equivalent to `$(view.el)` and `view.$(selector)` is equivalent to `$(view.el).find(selector)`. In our TodosView example's render method, we see `this.$el` used to set the HTML of the element and `this.$()` used to find subelements of class 'edit'.
+View logic often needs to invoke jQuery or Zepto functions on the `el` element and elements nested within it. Backbone makes it easy to do so by defining the `$el` property and `$()` function. The `view.$el` property is equivalent to `$(view.el)` and `view.$(selector)` is equivalent to `$(view.el).find(selector)`. In our TodoView example's render method, we see `this.$el` used to set the HTML of the element and `this.$()` used to find subelements of class 'edit'.
 
 **setElement**
 


### PR DESCRIPTION
The text was referencing to **TodosView** example, but actually the `render` method is inside **TodoView**.
