### PR TITLE
Improved template rendering and suggestion [no conflict]

### DIFF
--- a/chapters/02-fundamentals.md
+++ b/chapters/02-fundamentals.md
@@ -162,11 +162,11 @@ var TodoView = Backbone.View.extend({
 
   // Re-render the titles of the todo item.
   render: function() {
-    this.$el.html( this.todoTpl( this.model.toJSON() ) );
+    this.$el.html( this.todoTpl( this.model.attributes ) );
     // $el here is a reference to the jQuery element
     // associated with the view, todoTpl is a reference
-    // to an Underscore template and toJSON() returns an
-    // object containing the model's attributes
+    // to an Underscore template and model.attributes
+    // contains the attributes of the model.
     // Altogether, the statement is replacing the HTML of
     // a DOM element with the result of instantiating a
     // template with the model's attributes.

--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -411,7 +411,7 @@ var TodoView = Backbone.View.extend({
 
   // Re-render the title of the todo item.
   render: function() {
-    this.$el.html( this.todoTpl( this.model.toJSON() ) );
+    this.$el.html( this.todoTpl( this.model.attributes ) );
     this.input = this.$('.edit');
     return this;
   },

--- a/chapters/04-exercise-1.md
+++ b/chapters/04-exercise-1.md
@@ -504,7 +504,7 @@ Now let’s look at the `TodoView` view. This will be in charge of individual To
 
     // Re-renders the titles of the todo item.
     render: function() {
-      this.$el.html( this.template( this.model.toJSON() ) );
+      this.$el.html( this.template( this.model.attributes ) );
       this.$input = this.$('.edit');
       return this;
     },
@@ -652,7 +652,7 @@ The next part of our tutorial is going to cover completing and deleting todos. T
 
     // Re-render the titles of the todo item.
     render: function() {
-      this.$el.html( this.template( this.model.toJSON() ) );
+      this.$el.html( this.template( this.model.attributes ) );
 
       this.$el.toggleClass( 'completed', this.model.get('completed') ); // NEW
       this.toggleVisible();                                             // NEW

--- a/chapters/05-exercise-2.md
+++ b/chapters/05-exercise-2.md
@@ -223,7 +223,7 @@ app.BookView = Backbone.View.extend({
 
 	render: function() {
 		//this.el is what we defined in tagName. use $el to get access to jQuery html() function
-		this.$el.html( this.template( this.model.toJSON() ) );
+		this.$el.html( this.template( this.model.attributes ) );
 
 		return this;
 	}

--- a/chapters/06-extensions.md
+++ b/chapters/06-extensions.md
@@ -69,7 +69,7 @@ var MyView = Backbone.View.extend({
     var compiledTemplate = _.template(this.template);
 
     // render the template with the model data
-    var data = this.model.toJSON();
+    var data = _.clone(this.model.attributes);
     var html = compiledTemplate(data);
 
     // populate the view with the rendered html

--- a/chapters/08-modular-development.md
+++ b/chapters/08-modular-development.md
@@ -318,7 +318,7 @@ define( ["lib/backbone"], function ( Backbone ) {
     template: _.template($("#itemTemplate").html()),
 
     render: function() {
-      this.$el.html(this.template(this.model.toJSON()));
+      this.$el.html(this.template(this.model.attributes));
       return this;
     }
   });

--- a/chapters/09-exercise-3.md
+++ b/chapters/09-exercise-3.md
@@ -185,7 +185,7 @@ define([
 
     // Re-render the contents of the todo item.
     render: function() {
-      this.$el.html(this.template(this.model.toJSON()));
+      this.$el.html(this.template(this.model.attributes));
       this.setContent();
       return this;
     },

--- a/chapters/12-mobile-applications.md
+++ b/chapters/12-mobile-applications.md
@@ -276,7 +276,7 @@ define([
                 return "Edit Todo";
             },
             getSpecificTemplateValues : function () {
-                return this.model.toJSON();
+                return _.clone(this.model.attributes);
             },
             events : function () {
                 // merged events of BasicView, to add an older fix for back button functionality

--- a/chapters/13-unit-testing.md
+++ b/chapters/13-unit-testing.md
@@ -902,7 +902,7 @@ var TodoView = Backbone.View.extend({
   },
 
   render: function() {
-    this.$el.html(this.template(this.model.toJSON()));
+    this.$el.html(this.template(this.model.attributes));
     return this;
   },
 

--- a/chapters/18-appendix.md
+++ b/chapters/18-appendix.md
@@ -214,7 +214,7 @@ var todoView = new Cranium.View({
   template: _.template($('.todo-template').innerHTML),
 
   init: function (model) {
-    this.render( model.toJSON() );
+    this.render( model.attributes );
 
     this.on(model.id + 'update', this.render.bind(this));
   },
@@ -340,7 +340,7 @@ app.TodoView = Backbone.View.extend({
 
   // Re-render the titles of the todo item.
   render: function() {
-    this.$el.html( this.template( this.model.toJSON() ) );
+    this.$el.html( this.template( this.model.attributes ) );
     return this;
   },
 


### PR DESCRIPTION
It is a better approach to use `model.attributes` instead of `model.toJSON()` when rendering templates, to allow scenarios when one wishes to alter the payload that is sent to the server. The `toJSON` function is used in [Backbone.sync](https://github.com/jashkenas/backbone/blob/master/backbone.js#L1212) for parsing.

In a situation where one would use an attribute called `description` in the model, but the server is expecting `desc`, one could solve this by overriding the `toJSON` function in the following manner:

``` javascript
var MyModel = new Backbone.Model.extend({
  toJSON: function() {
    var attrs = _.clone(this.attributes);

    attrs.desc = attrs.description;
    delete attrs.description;

    return attrs;
  }
});
```

I think it might be useful to add a section in the book describing how to handle situations like this and the fact that `model.attributes` should be used when rendering templates to allow this kind of functionality.
