### PR TITLE
Put file globs in code spans

### DIFF
--- a/chapters/09-exercise-3.md
+++ b/chapters/09-exercise-3.md
@@ -474,7 +474,7 @@ For more than trivial views, DocumentCloud have a home-built asset packager call
 
 Jammit expects your JavaScript templates (JST) to live alongside any ERB templates you're using in the form of .jst files. It packages the templates into a global JST object which can be used to render templates into strings. Making Jammit aware of your templates is straight-forward - just add an entry for something like `views/**/*.jst` to your app package in assets.yml.
 
-To provide Jammit dependencies you simply write out an assets.yml file that either listed the dependencies in order or used a combination of free capture directories (for example: /**/*.js, templates/*.js, and specific files). 
+To provide Jammit dependencies you simply write out an assets.yml file that either listed the dependencies in order or used a combination of free capture directories (for example: `/**/*.js`, `templates/*.js`, and specific files). 
 
 A template using Jammit can derive it's data from the collection object that is passed to it:
 


### PR DESCRIPTION
Depending on the renderer the asterisks may be interpreted as markdown characters
and alter the style of the text (and in some cases make the asterisks disappear).
