### PR TITLE
Fixes for example section in qunit/sinonjs section

### DIFF
--- a/chapters/15-sinonjs.md
+++ b/chapters/15-sinonjs.md
@@ -330,9 +330,9 @@ For our collection we'll want to test that:
 * The order for Todos is numerically correct
 
 ```javascript
-  describe('Test Collection', function() {
+  module('Test Collection', {
 
-    beforeEach(function() {
+    setup: function() {
 
       // Define new todos
       this.todoOne = new Todo;
@@ -341,52 +341,47 @@ For our collection we'll want to test that:
       });
 
       // Create a new collection of todos for testing
-      return this.todos = new TodoList([this.todoOne, this.todoTwo]);
-    });
+      this.todos = new TodoList([this.todoOne, this.todoTwo]);
+    }
+  });
 
-    it('Has the Todo model', function() {
+    test('Has the Todo model', function() {
       equal(this.todos.model, Todo);
     });
 
-    it('Uses local storage', function() {
+    test('Uses local storage', function() {
       equal(this.todos.localStorage, new Store('todos-backbone'));
     });
 
-    describe('done', function() {
-      return it('returns an array of the todos that are done', function() {
+    // done
+      test('returns an array of the todos that are done', function() {
         this.todoTwo.done = true;
         deepEqual(this.todos.done(), [this.todoTwo]);
       });
-    });
 
-    describe('remaining', function() {
-      return it('returns an array of the todos that are not done', function() {
+    // remaining
+      test('returns an array of the todos that are not done', function() {
         this.todoTwo.done = true;
         deepEqual(this.todos.remaining(), [this.todoOne]);
       });
-    });
 
-    describe('clear', function() {
-      return it('destroys the current todo from local storage', function() {
+    // clear
+      test('destroys the current todo from local storage', function() {
         deepEqual(this.todos.models, [this.todoOne, this.todoTwo]);
         this.todos.clear(this.todoOne);
         deepEqual(this.todos.models, [this.todoTwo]);
       });
-    });
 
-    return describe('Order sets the order on todos ascending numerically', function() {
-      it('defaults to one when there arent any items in the collection', function() {
+    // Order sets the order on todos ascending numerically
+      test('defaults to one when there arent any items in the collection', function() {
         this.emptyTodos = new TodoApp.Collections.TodoList;
         equal(this.emptyTodos.order(), 0);
       });
 
-      return it('Increments the order by one each time', function() {
+      test('Increments the order by one each time', function() {
         equal(this.todos.order(this.todoOne), 1);
         equal(this.todos.order(this.todoTwo), 2);
       });
-    });
-
-  });
 ```
 
 

--- a/chapters/15-sinonjs.md
+++ b/chapters/15-sinonjs.md
@@ -450,7 +450,7 @@ asyncTest('Can wire up view methods to DOM elements.', function() {
         start();
     }, 1000, 'Expected DOM Elt to exist');
 
-    // Trigget the view to toggle the 'done' status on an item or items
+    // Trigger the view to toggle the 'done' status on an item or items
     $('#todoList li input.check').click();
 
     // Check the done status for the model is true

--- a/chapters/15-sinonjs.md
+++ b/chapters/15-sinonjs.md
@@ -346,27 +346,32 @@ For our collection we'll want to test that:
   });
 
     test('Has the Todo model', function() {
+      expect( 1 );
       equal(this.todos.model, Todo);
     });
 
     test('Uses local storage', function() {
+      expect( 1 );
       equal(this.todos.localStorage, new Store('todos-backbone'));
     });
 
     // done
       test('returns an array of the todos that are done', function() {
+        expect( 1 );
         this.todoTwo.done = true;
         deepEqual(this.todos.done(), [this.todoTwo]);
       });
 
     // remaining
       test('returns an array of the todos that are not done', function() {
+        expect( 1 );
         this.todoTwo.done = true;
         deepEqual(this.todos.remaining(), [this.todoOne]);
       });
 
     // clear
       test('destroys the current todo from local storage', function() {
+        expect( 2 );
         deepEqual(this.todos.models, [this.todoOne, this.todoTwo]);
         this.todos.clear(this.todoOne);
         deepEqual(this.todos.models, [this.todoTwo]);
@@ -374,11 +379,13 @@ For our collection we'll want to test that:
 
     // Order sets the order on todos ascending numerically
       test('defaults to one when there arent any items in the collection', function() {
+        expect( 1 );
         this.emptyTodos = new TodoApp.Collections.TodoList;
         equal(this.emptyTodos.order(), 0);
       });
 
       test('Increments the order by one each time', function() {
+        expect( 2 );
         equal(this.todos.order(this.todoOne), 1);
         equal(this.todos.order(this.todoTwo), 2);
       });

--- a/chapters/15-sinonjs.md
+++ b/chapters/15-sinonjs.md
@@ -345,44 +345,44 @@ For our collection we'll want to test that:
     });
 
     it('Has the Todo model', function() {
-      return expect(this.todos.model).toBe(Todo);
+      equal(this.todos.model, Todo);
     });
 
     it('Uses local storage', function() {
-      return expect(this.todos.localStorage).toEqual(new Store('todos-backbone'));
+      equal(this.todos.localStorage, new Store('todos-backbone'));
     });
 
     describe('done', function() {
       return it('returns an array of the todos that are done', function() {
         this.todoTwo.done = true;
-        return expect(this.todos.done()).toEqual([this.todoTwo]);
+        deepEqual(this.todos.done(), [this.todoTwo]);
       });
     });
 
     describe('remaining', function() {
       return it('returns an array of the todos that are not done', function() {
         this.todoTwo.done = true;
-        return expect(this.todos.remaining()).toEqual([this.todoOne]);
+        deepEqual(this.todos.remaining(), [this.todoOne]);
       });
     });
 
     describe('clear', function() {
       return it('destroys the current todo from local storage', function() {
-        expect(this.todos.models).toEqual([this.todoOne, this.todoTwo]);
+        deepEqual(this.todos.models, [this.todoOne, this.todoTwo]);
         this.todos.clear(this.todoOne);
-        return expect(this.todos.models).toEqual([this.todoTwo]);
+        deepEqual(this.todos.models, [this.todoTwo]);
       });
     });
 
     return describe('Order sets the order on todos ascending numerically', function() {
       it('defaults to one when there arent any items in the collection', function() {
         this.emptyTodos = new TodoApp.Collections.TodoList;
-        return expect(this.emptyTodos.order()).toEqual(0);
+        equal(this.emptyTodos.order(), 0);
       });
 
       return it('Increments the order by one each time', function() {
-        expect(this.todos.order(this.todoOne)).toEqual(1);
-        return expect(this.todos.order(this.todoTwo)).toEqual(2);
+        equal(this.todos.order(this.todoOne), 1);
+        equal(this.todos.order(this.todoTwo), 2);
       });
     });
 

--- a/practicals/qunit-koans/specrunner.html
+++ b/practicals/qunit-koans/specrunner.html
@@ -10,7 +10,7 @@
     <script type="text/javascript" src="js/todos.js"></script>
     
 
-    <script type="text/javascript" src="http://code.jquery.com/qunit/qunit-git.js"></script>
+    <script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.2.0.js"></script>
 <link rel="stylesheet" type="text/css" href="http://code.jquery.com/qunit/qunit-1.2.0.css">
 
     <script type="text/javascript" src="js/koans/aboutEvents.js"></script>


### PR DESCRIPTION
I noticed that one of the example sections ("collections") in the qunit/sinonjs chapter was using the jasmine functions (describe, expect, it) instead of the qunit style so I migrated the code with as few changes as possible.

I loaded it into the qunit-koans section to verify, which is where I found that the latest git version of qunit doesn't have `expect` as a global anymore, so I pinned the version of qunit to match the css version used there so that the koan tests would pass initially (or more specifically so that the test suite would actually run).

So this updated section doesn't pass (I believe because it is an excerpt and not complete), but it does actually run to the end of the suite, so it's better than it was before.

Feel free to cherry-pick if you don't want all of the changes.  I tried to aim for consistency with the rest of the examples but they aren't all necessary or maybe they're not quite your style.

Thanks for the great book, I've really enjoyed it.
