### PR TITLE
change Marionette event

### DIFF
--- a/chapters/06-extensions.md
+++ b/chapters/06-extensions.md
@@ -332,7 +332,7 @@ TodoMVC.addRegions({
   footer: '#footer'
 });
 
-TodoMVC.on('initialize:after', function() {
+TodoMVC.on('start', function() {
   Backbone.history.start();
 });
 ```


### PR DESCRIPTION
The new version of Marionette uses before:start and start instead of initialize:after
