### PR TITLE
Removed comma

### DIFF
--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -712,7 +712,7 @@ var Todo = Backbone.Model.extend({
 });
 
 var TodosCollection = Backbone.Collection.extend({
-  model: Todo,
+  model: Todo
 });
 
 var a = new Todo({ title: 'Go to Jamaica.'}),


### PR DESCRIPTION
Location: In one of the earlier sections of the book under Collections and 'Adding and Removing Models'

Change suggested: Did not edit anything besides removing what I thought was an unnecessary comma. It seems there shouldn't be a comma when there is only 1 item inside an an .extend({})

BEFORE
![screen shot 2014-11-14 at 7 18 44 am](https://cloud.githubusercontent.com/assets/8462738/5047073/d9fe6fa6-6bce-11e4-8149-e31898f8658b.png)

AFTER
![screen shot 2014-11-14 at 7 21 48 am](https://cloud.githubusercontent.com/assets/8462738/5047090/094896a6-6bcf-11e4-8ab1-cf2ce3390b5d.png)
