### PR TITLE
Spelling error

### DIFF
--- a/index.html
+++ b/index.html
@@ -7562,7 +7562,7 @@ data-shadow=<span class="st">&quot;true&quot;</span> data-iconshadow=<span class
     <span class="co">// Create a new spy</span>
     <span class="kw">var</span> callback = <span class="ot">jasmine</span>.<span class="fu">createSpy</span>();
 
-    <span class="co">// Exexute the spy callback if the</span>
+    <span class="co">// Execute the spy callback if the</span>
     <span class="co">// request for Todo 15 is successful</span>
     <span class="fu">getTodo</span>(<span class="dv">15</span>, callback);
 


### PR DESCRIPTION
Correct spelling of `execute`
