### PR TITLE
Update '$' definition in 18-appendix.md

### DIFF
--- a/chapters/18-appendix.md
+++ b/chapters/18-appendix.md
@@ -18,7 +18,7 @@ At the heart of our JavaScript MVC implementation is an `Event` system (object) 
 var Cranium = Cranium || {};
 
 // Set DOM selection utility
-var $ = document.querySelector.bind(document) || this.jQuery || this.Zepto;
+var $ = this.jQuery || this.Zepto || document.querySelectorAll.bind(document);
 
 // Mix in to any object in order to provide it with custom events.
 var Events = Cranium.Events = {


### PR DESCRIPTION
Change to use document.querySelectorAll to reflect change in Cranium gist, as well as reorder expressions to allow jQuery or Zepto to be used if defined, instead of always evaluating to `document.querySelector.bind(document)`
