### PR TITLE
Change name of model in rectifying zombie view example

### DIFF
--- a/chapters/06-extensions.md
+++ b/chapters/06-extensions.md
@@ -218,17 +218,17 @@ var Jeremy = new Person({
 
 // create the first view instance
 var zombieView = new ZombieView({
-  model: Person
+  model: Jeremy
 })
 zombieView.close(); // double-tap the zombie
 
 // create a second view instance, re-using
 // the same variable name to store it
 zombieView = new ZombieView({
-  model: Person
+  model: Jeremy
 })
 
-Person.set('email', 'jeremyashkenas@example.com');
+Jeremy.set('email', 'jeremyashkenas@example.com');
 ```
 
 Now we only see one alert box when this code runs. 


### PR DESCRIPTION
The second example which illustrates the `close` method on view which facilitates the view to unbind all events before falling out of scope _has a subtle typo_.

We define a model `Jeremy` but use the Backbone model template _Person_ to declare the views and later change the email on it.
