### PR TITLE
fixed example code typo

### DIFF
--- a/chapters/07-common-problems.md
+++ b/chapters/07-common-problems.md
@@ -767,7 +767,7 @@ var Panel = Backbone.View.extend({
 
 var PanelAdvanced = Panel.extend({
   initialize: function(options){
-    Panel.prototype.initialize.call(this, [options]);
+    Panel.prototype.initialize.call(this, options);
     console.log('PanelAdvanced initialized');
     console.log(this.foo); // Log: bar
   }
@@ -776,7 +776,7 @@ var PanelAdvanced = Panel.extend({
 // We can also inherit PanelAdvanced if needed
 var PanelAdvancedExtra = PanelAdvanced.extend({
   initialize: function(options){
-    PanelAdvanced.prototype.initialize.call(this, [options]);
+    PanelAdvanced.prototype.initialize.call(this, options);
     console.log('PanelAdvancedExtra initialized');
   }
 });


### PR DESCRIPTION
Passing `options` in an array would be ok if we were invoking `.apply()` on Panel.prototype.initialize
But since we are invoking `.call()` it shouldn't be.
