### PR TITLE
Chapter 4 Exercise 1 router.js sample code: declare app object

### DIFF
--- a/chapters/04-exercise-1.md
+++ b/chapters/04-exercise-1.md
@@ -757,6 +757,8 @@ When the route changes, the todo list will be filtered on a model level and the 
   // Todo Router
   // ----------
 
+  var app = app || {};
+
   var Workspace = Backbone.Router.extend({
     routes:{
       '*filter': 'setFilter'


### PR DESCRIPTION
fixes `app is not defined` error because the example code for router.js is missing the app var.

also needs fixing in chapter 6
