### PR TITLE
configuration typo fixed

### DIFF
--- a/backbone-fundamentals.md
+++ b/backbone-fundamentals.md
@@ -7274,7 +7274,7 @@ The rest of the tutorial will now focus on the JavaScript side of the practical.
 
 ### Configuration options
 
-If you've read the earlier chapter on AMD, you may have noticed that explicitly needing to define each dependency a Backbone module (view, collection or other module) may require with it can get a little tedious. This can however be improved.
+If you've read the earlier chapter on AMD, you may have noticed that explicitly needing to define each dependency as a Backbone module (view, collection or other module) can get a little tedious. This can however be improved.
 
 In order to simplify referencing common paths the modules in our application may use, we use a RequireJS [configuration object](http://requirejs.org/docs/api.html#config), which is typically defined as a top-level script file. Configuration objects have a number of useful capabilities, the most useful being mode name-mapping. Name-maps are basically a key:value pair, where the key defines the alias you wish to use for a path and the value represents the true location of the path.
 


### PR DESCRIPTION
Fixing the typo referenced in Issue #647. Changed 

"If you’ve read the earlier chapter on AMD, you may have noticed that explicitly needing to define each dependency a Backbone module (view, collection or other module) may require with it can get a little tedious."

to 

"If you've read the earlier chapter on AMD, you may have noticed that explicitly needing to define each dependency as a Backbone module (view, collection or other module) can get a little tedious. This can however be improved" 
