### PR TITLE
Fix typo – from: togglecompleted, to: toggleCompleted

### DIFF
--- a/chapters/04-exercise-1.md
+++ b/chapters/04-exercise-1.md
@@ -634,7 +634,7 @@ The next part of our tutorial is going to cover completing and deleting todos. T
 
     // The DOM events specific to an item.
     events: {
-      'click .toggle': 'togglecompleted', // NEW
+      'click .toggle': 'toggleCompleted', // NEW
       'dblclick label': 'edit',
       'click .destroy': 'clear',           // NEW
       'keypress .edit': 'updateOnEnter',


### PR DESCRIPTION
In Chapter 4, Completing & deleting todos
(`js/views/todos.js`),
from `togglecompleted` to `toggleCompleted`
