### PR TITLE
Added missing 'validates' option to 'set' method

### DIFF
--- a/chapters/13-unit-testing.md
+++ b/chapters/13-unit-testing.md
@@ -455,7 +455,7 @@ it('Can contain custom validation rules, and will trigger an invalid event on fa
     // What would you need to set on the todo properties to
     // cause validation to fail?
 
-    todo.set({done:'a non-boolean value'});
+    todo.set({done:'a non-boolean value'}, {validate: true});
 
     var errorArgs = errorCallback.mostRecentCall.args;
 


### PR DESCRIPTION
I noticed that the example code is missing an option to trigger validation.  

As specified in the docs, if the `set()` method only validates if `{validate: true}` is passed as an option.
http://backbonejs.org/#Model-validate
