### PR TITLE
Update links in boilerplate template

### DIFF
--- a/chapters/03-internals.md
+++ b/chapters/03-internals.md
@@ -18,8 +18,8 @@ You can paste the following into your text editor of choice, replacing the comme
 <body>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script src="http://documentcloud.github.com/underscore/underscore-min.js"></script>
-<script src="http://documentcloud.github.com/backbone/backbone-min.js"></script>
+<script src="http://underscorejs.org/underscore-min.js"></script>
+<script src="http://backbonejs.org/backbone-min.js"></script>
 <script>
   // Your code goes here
 </script>


### PR DESCRIPTION
Change the links for backbone and underscore in the boilerplate template to backbonejs.org and underscorejs.org respectively.

Fixes #689
