### PR TITLE
Fix issue 722 open string at line 512

### DIFF
--- a/chapters/05-exercise-2.md
+++ b/chapters/05-exercise-2.md
@@ -509,7 +509,7 @@ app.configure( function() {
 	app.use( app.router );
 
 	//Where to serve static content
-	app.use( express.static( path.join( application_root, '../', site') ) );
+	app.use( express.static( path.join( application_root, '../', 'site') ) );
 
 	//Show all errors in development
 	app.use( express.errorHandler({ dumpExceptions: true, showStack: true }));


### PR DESCRIPTION
Closed single quotes around string in example code so that it renders:

```javascript
//Where to serve static content
app.use( express.static( path.join( application_root, '../', 'site') ) );
```

instead of:

```javascript
//Where to serve static content
app.use( express.static( path.join( application_root, '../', site') ) );
```